### PR TITLE
Adds hook to dump supermodule state info into repo

### DIFF
--- a/hooks/multihooks.py
+++ b/hooks/multihooks.py
@@ -44,6 +44,7 @@ installed.
 """
 
 from sys import argv
+import os
 from logging import getLogger
 from subprocess import Popen, PIPE
 from os import access, listdir, X_OK, environ
@@ -127,9 +128,10 @@ def main():
     for h in hooks:
         hook_id = '{}.d/{}'.format(hook_type, basename(h))
         log.info('Running hook {}...'.format(hook_id))
-
+        cwd = os.getcwd()
         proc = Popen([h] + argv[1:], stdout=PIPE, stderr=PIPE)
         stdout_raw, stderr_raw = proc.communicate()
+        os.chdir(cwd)
 
         stdout = stdout_raw.decode('utf-8').strip()
         stderr = stderr_raw.decode('utf-8').strip()

--- a/hooks/pre-commit.d/03-record-supermodule-commit.py
+++ b/hooks/pre-commit.d/03-record-supermodule-commit.py
@@ -9,27 +9,45 @@ import subprocess
 from configparser import ConfigParser
 from functools import partial
 
-root = Path(os.getcwd())
+get_output = partial(subprocess.check_output, universal_newlines=True)
+root = Path(get_output(['git', 'rev-parse', '--show-toplevel']).strip())
 supermod = Path(root, '..')
 modfile_fn = root / '.gitsuper'
-get_output = partial(subprocess.check_output, universal_newlines=True)
+
+
+def get_env(mod):
+    env = os.environ.copy()
+    env['GIT_WORKING_TREE'] = str(mod)
+    env['GIT_DIR'] = str(mod / '.git')
+    del env['GIT_INDEX_FILE']
+    return env
+
 
 def for_module(cf, mod, section=None):
+    mod = mod.resolve()
+    logging.error('entering {}'.format(mod))
     os.chdir(mod)
-    remote = get_output(['git', 'remote', 'get-url', 'origin']).strip()
-    status = get_output(['git', 'submodule', 'status']).strip()
-    commit = get_output(['git', 'rev-parse', 'HEAD']).strip()
+    env = get_env(mod)
+    remote = get_output(['git', 'remote', 'get-url', 'origin'], env=env).strip()
+    commit = get_output(['git', 'rev-parse', 'HEAD'], env=env).strip()
     section = section or 'submodule.{}'.format(mod.name)
     cf.add_section(section)
     cf.set(section, 'remote', remote)
-    if status:
+    try:
+        status = get_output(['git', 'submodule', 'status'], env=env).strip()
         cf.set(section, 'status', status)
+    except subprocess.CalledProcessError:
+        pass
     cf.set(section, 'commit', commit)
 
 cf = ConfigParser()
 for_module(cf, supermod, 'supermodule')
 os.chdir(supermod)
 for s in [Path(s) for s in
-              get_output(['git', 'submodule', '--quiet', 'foreach', 'pwd']).split()]:
+              get_output(['git', 'submodule', '--quiet', 'foreach', 'pwd'],
+                         env=get_env(supermod)).split()]:
     for_module(cf, s)
 cf.write(open(modfile_fn, 'wt'))
+
+os.chdir(root)
+subprocess.check_call(['git', 'add', str(modfile_fn)])

--- a/hooks/pre-commit.d/03-record-supermodule-commit.py
+++ b/hooks/pre-commit.d/03-record-supermodule-commit.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+""" Put the supermodules's remote, status and commit
+into .gitsuper
+"""
+import sys
+import os
+from pathlib import Path
+import subprocess
+from configparser import ConfigParser
+
+
+root = Path(os.getcwd())
+supermod = Path(root, '..')
+modfile_fn = root / '.gitsuper'
+os.chdir(supermod)
+remote = subprocess.check_output(['git', 'remote', 'get-url', 'origin'], universal_newlines=True)
+status = subprocess.check_output(['git', 'submodule', 'status'], universal_newlines=True)
+commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], universal_newlines=True)
+section = 'supermodule'
+cf = ConfigParser(default_section=section)
+cf.set(section, 'remote', remote)
+cf.set(section, 'status', status)
+cf.set(section, 'commit', commit)
+cf.write(open(modfile_fn, 'wt'))


### PR DESCRIPTION
This puts the actually used commits and stuff for all submodules into the current commit.
Example: https://github.com/dune-community/dune-xt-common/compare/super_recording
It's prolly not ideal, but I got really tired of the switching between commit combinations that aren't working together. 

Comments @dune-community/dune-xt-contributors , @dune-community/dune-xt-devs ?